### PR TITLE
remove numpy pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 dynamic = ["description", "version"]
 requires-python = ">=3.7"
 dependencies = [
-    'numpy>=2',
+    'numpy',
     'requests',
     'scipy>=1.5.0',
     'sympy',


### PR DESCRIPTION
remove numpy pin because numpy v2 fails in WASM.